### PR TITLE
Fix for the issue where `filePath` was still required when providing `docs` in retriever config #33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oconva/qvikchat",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oconva/qvikchat",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@genkit-ai/ai": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oconva/qvikchat",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/oconva/qvikchat.git"

--- a/src/rag/data-loaders/data-loaders.ts
+++ b/src/rag/data-loaders/data-loaders.ts
@@ -120,13 +120,19 @@ export function validateDataType(filePath: string):
  * For more data loaders, see:
  * @link https://js.langchain.com/v0.1/docs/integrations/document_loaders/
  */
-export const getDocs = async (
-  dataLoaderType: SupportedDataLoaderTypes,
-  path: string,
-  jsonLoaderKeysToInclude?: JSONLoaderKeysToInclude,
-  csvLoaderOptions?: CSVLoaderOptions,
-  pdfLoaderOptions?: PDFLoaderOptions
-): Promise<Document<Record<string, string>>[]> => {
+export const getDocs = async ({
+  dataLoaderType,
+  path,
+  jsonLoaderKeysToInclude,
+  csvLoaderOptions,
+  pdfLoaderOptions,
+}: {
+  dataLoaderType: SupportedDataLoaderTypes;
+  path: string;
+  jsonLoaderKeysToInclude?: JSONLoaderKeysToInclude;
+  csvLoaderOptions?: CSVLoaderOptions;
+  pdfLoaderOptions?: PDFLoaderOptions;
+}): Promise<Document<Record<string, string>>[]> => {
   // store loader
   let loader;
   // infer loader to use based on dataLoaderType


### PR DESCRIPTION

[fix for](https://github.com/oconva/qvikchat/commit/5efbe78470433fc44cdf5e4c4d5275f0d507fc52) https://github.com/oconva/qvikchat/issues/33 [- refactored code for data retriever](https://github.com/oconva/qvikchat/commit/5efbe78470433fc44cdf5e4c4d5275f0d507fc52)

[Bumped package version](https://github.com/oconva/qvikchat/commit/b85961daccf931c2cb4650e4b8e90f14df98204a) https://github.com/oconva/qvikchat/issues/33